### PR TITLE
OSU-200

### DIFF
--- a/app/services/ResearchDataHelper.java
+++ b/app/services/ResearchDataHelper.java
@@ -146,7 +146,7 @@ public class ResearchDataHelper {
    */
   public static LinkedHashMap<String, String> getAgentAffiliationMap(String agentType) {
     LinkedHashMap<String, String> map = new LinkedHashMap<>();
-    map.put(null, "Bitte wählen Sie...");
+    map.put("http://hbz-nrw.de/regal#affiliation/unknown", "Bitte wählen Sie...");
     GenericPropertiesLoader GenProp = new GenericPropertiesLoader();
     map.putAll(GenProp.loadVocabMap(agentType + "ResearchOrganizationsRegistry-de.properties"));
     return map;


### PR DESCRIPTION
The Affiliation element should be omitted if no specification is made.
The value of "Bitte wählen Sie..." in the method getAgentAffiliationMap() was changed from "null" to ""http://hbz-nrw.de/regal#affiliation/unknown" analogous to the method getAgentAcademicDegreeMap().
Works with Branch OSU-200 of to.science.api.